### PR TITLE
feat: Add interactive language selection for container builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,83 +1,27 @@
-# System files
+# Temporary build directory
+.build-temp/
+
+# OS generated files
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
 Thumbs.db
-*.swp
-*.swo
-*~
 
 # Editor directories and files
 .idea/
 .vscode/
-*.sublime-project
-*.sublime-workspace
-*.code-workspace
-
-# Docker & container artifacts
-.docker/
-*.tar
-*.log
-docker-compose.override.yml
-
-# Kubernetes generated files
-kubeconfig
-*.kubeconfig
-.kube/
-*.yaml.bak
-
-# Node.js and npm artifacts (if testing locally)
-node_modules/
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-package-lock.json
-yarn.lock
-
-# Credentials and secrets
-.env
-.env.*
-*.pem
-*.key
-*_id_rsa
-*_id_dsa
-*.crt
-kubeconfig
-.kube/
-.config/
-secrets/
-
-# Build artifacts and temporary files
-/build/
-/dist/
-/tmp/
-.cache/
-*.tar.gz
-*.tgz
-.terraform/
-
-# Testing
-/coverage/
-*.test.js
-*.spec.js
-/test-results/
+*.swp
+*.swo
+*~
 
 # Logs
-logs/
 *.log
-npm-debug.log*
 
-# Local runtime data
-pids
-*.pid
-*.seed
-*.pid.lock
+# Kubernetes generated files
+*.kubeconfig
 
-# API keys and secrets
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-# Specific to this project
-# Uncomment as needed for your specific use case
-# custom-values.yaml
-# local-testing/
+# Docker
+.dockerignore.local

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,14 +1,11 @@
-# DEPRECATED: This file is kept for backward compatibility
-# Please use Dockerfile.base with the build-and-deploy.sh script
-# which allows you to select additional languages to include
-
 FROM ubuntu:22.04
 
-# Setup environment for arm64 architecture
+# Set architecture (defaults to arm64 for Apple Silicon)
 ARG TARGETARCH=arm64
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
+ENV TARGETARCH=${TARGETARCH}
 
 # Install dependencies (excluding Node.js)
 RUN apt-get update && apt-get install -y \
@@ -48,6 +45,8 @@ RUN which claude || (echo "Claude Code installation failed" && exit 1)
 
 # Create a directory for user configuration
 RUN mkdir -p /root/.config/claude-code
+
+# LANGUAGE_INSTALLATIONS_PLACEHOLDER
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,45 @@
-# Claude Code in Kubernetes
+### Customizing Language Options
+
+To add or modify available languages, edit the `languages.conf` file. The format is:
+```
+LANGUAGE_ID|Display Name|Installation Commands
+```
+
+For example:
+```
+PYTHON_3_13|Python 3.13|RUN apt-get update && apt-get install -y python3.13
+```
+
+The installation commands should be valid Dockerfile RUN instructions.## Features
+
+- **Containerized Claude Code**: Run Anthropic's AI coding assistant in an isolated Kubernetes environment
+- **Language Selection**: Optionally include additional programming languages and tools in your container
+- **Persistent Storage**: Configuration and workspace data persist across container restarts
+- **Security**: Runs as non-root user with proper isolation
+- **Easy Deployment**: Single script to build and deploy
+
+## Language Support
+
+The build script includes an interactive language selection menu. When you run the build script:
+
+1. The screen will clear and show a list of available languages
+2. Use **↑/↓ arrow keys** or **j/k** to move the cursor
+3. Press **SPACE** to select/deselect a language (selected items show ✓)
+4. Press **ENTER** to confirm your selections and continue
+5. Press **q** to quit without building
+
+Available languages include:
+
+- **Python**: 3.10, 3.11, 3.12
+- **Rust**: Latest stable, Nightly
+- **Go**: 1.21, 1.22
+- **Ruby**: 3.2, 3.3 (via rbenv)
+- **Java**: OpenJDK 11, 17, 21
+- **.NET**: 6.0, 8.0
+- **PHP**: 8.2, 8.3
+- **And more**: Elixir, Kotlin, Swift
+
+To add more languages, edit the `languages.conf` file.# Claude Code in Kubernetes
 
 This project provides a containerized version of Claude Code running in Kubernetes, allowing you to use Anthropic's AI coding assistant in an isolated environment rather than directly on your host OS.
 
@@ -6,9 +47,12 @@ This project provides a containerized version of Claude Code running in Kubernet
 
 ```
 claude-code-k8s/
-├── Dockerfile              # Container definition for Claude Code
+├── Dockerfile              # Container definition for Claude Code (deprecated - use Dockerfile.base)
+├── Dockerfile.base         # Base container definition
+├── languages.conf          # Language installation configurations
 ├── entrypoint.sh           # Container startup script
 ├── build-and-deploy.sh     # Helper script for building and deploying
+├── .gitignore              # Git ignore file
 ├── kubernetes/
 │   ├── namespace.yaml      # Kubernetes namespace definition
 │   ├── pvc.yaml            # Persistent volume claims for configuration and workspace
@@ -28,8 +72,11 @@ cd claude-code-k8s
 # Make the script executable
 chmod +x build-and-deploy.sh
 
-# Build and deploy
+# Build and deploy (with language selection)
 ./build-and-deploy.sh
+
+# Or build without language selection (base image only)
+./build-and-deploy.sh --no-select
 
 # Connect to the container
 kubectl exec -it -n claude-code <pod-name> -- bash
@@ -60,8 +107,14 @@ The repository includes a build script that automates the process, but you can a
 # Using the script (for Colima)
 ./build-and-deploy.sh
 
+# Skip language selection (base image only)
+./build-and-deploy.sh --no-select
+
+# Clean rebuild
+./build-and-deploy.sh --clean
+
 # Building manually
-docker build -t claude-code:latest .
+docker build -t claude-code:latest -f .build-temp/Dockerfile .
 ```
 
 For other container systems:

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -5,11 +5,14 @@ set -e
 IMAGE_NAME="claude-code"
 IMAGE_TAG="latest"
 NAMESPACE="claude-code"
+TEMP_DIR=".build-temp"
+LANGUAGES_CONFIG="languages.conf"
 
 # Colors for output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${YELLOW}=== Building Claude Code Container for Kubernetes ===${NC}"
@@ -27,6 +30,170 @@ fi
 
 if ! command -v colima &> /dev/null; then
     echo -e "${RED}Error: colima is not installed or not in PATH${NC}"
+    exit 1
+fi
+
+# Function to display language selection menu
+select_languages() {
+    # Clear the screen for better menu display
+    clear
+    
+    echo -e "${BLUE}=== Language Selection ===${NC}"
+    echo -e "Select additional languages to include in the container.\n"
+    echo -e "${YELLOW}Instructions:${NC}"
+    echo -e "  ↑/↓ or j/k = Move cursor"
+    echo -e "  SPACE = Toggle selection"
+    echo -e "  ENTER = Confirm selections"
+    echo -e "  q = Quit without building\n"
+    
+    # Read available languages from config
+    local languages=()
+    local display_names=()
+    local installations=()
+    local selected=()
+    
+    while IFS='|' read -r lang_id display_name installation; do
+        # Skip empty lines and comments
+        [[ -z "$lang_id" || "$lang_id" =~ ^# ]] && continue
+        
+        languages+=("$lang_id")
+        display_names+=("$display_name")
+        installations+=("$installation")
+        selected+=(false)
+    done < "$LANGUAGES_CONFIG"
+    
+    local current=0
+    local key=""
+    
+    # Save cursor position
+    tput sc
+    
+    # Hide cursor
+    tput civis
+    
+    # Initial display
+    for i in "${!languages[@]}"; do
+        echo ""
+    done
+    
+    # Display menu
+    while true; do
+        # Restore cursor position
+        tput rc
+        
+        # Display options
+        for i in "${!languages[@]}"; do
+            # Clear the line
+            tput el
+            
+            if [[ $i -eq $current ]]; then
+                echo -ne "${BLUE}▸${NC}"
+            else
+                echo -ne " "
+            fi
+            
+            if [[ ${selected[$i]} == true ]]; then
+                echo -e " ${GREEN}[✓]${NC} ${display_names[$i]}"
+            else
+                echo -e " [ ] ${display_names[$i]}"
+            fi
+        done
+        
+        # Read key - handle both single chars and escape sequences
+        IFS= read -rsn1 key
+        
+        # Handle different key types
+        if [[ $key == $'\e' ]]; then
+            # Escape sequence (arrow keys)
+            read -rsn2 key
+            case "$key" in
+                "[A"|"OA") # Up arrow
+                    ((current > 0)) && ((current--))
+                    ;;
+                "[B"|"OB") # Down arrow
+                    ((current < ${#languages[@]} - 1)) && ((current++))
+                    ;;
+            esac
+        elif [[ ${#key} -eq 0 ]]; then
+            # Enter key (empty string)
+            break
+        elif [[ "$key" == " " ]]; then
+            # Space - toggle selection
+            if [[ ${selected[$current]} == true ]]; then
+                selected[$current]=false
+            else
+                selected[$current]=true
+            fi
+        elif [[ "$key" == "k" ]] || [[ "$key" == "K" ]]; then
+            # vim-style up
+            ((current > 0)) && ((current--))
+        elif [[ "$key" == "j" ]] || [[ "$key" == "J" ]]; then
+            # vim-style down
+            ((current < ${#languages[@]} - 1)) && ((current++))
+        elif [[ "$key" == "q" ]] || [[ "$key" == "Q" ]]; then
+            # Quit
+            tput cnorm
+            clear
+            echo -e "${YELLOW}Installation cancelled.${NC}"
+            exit 0
+        fi
+    done
+    
+    # Show cursor
+    tput cnorm
+    
+    # Clear and show results
+    clear
+    
+    # Build installation commands for selected languages
+    SELECTED_INSTALLATIONS=""
+    echo -e "${GREEN}Selected languages:${NC}"
+    local any_selected=false
+    
+    for i in "${!languages[@]}"; do
+        if [[ ${selected[$i]} == true ]]; then
+            echo -e "  ✓ ${display_names[$i]}"
+            SELECTED_INSTALLATIONS+="\n${installations[$i]}\n"
+            any_selected=true
+        fi
+    done
+    
+    if [[ $any_selected == false ]]; then
+        echo -e "  None (base image only)"
+    fi
+    
+    echo ""
+}
+
+# Function to create custom Dockerfile
+create_custom_dockerfile() {
+    mkdir -p "$TEMP_DIR"
+    
+    # Copy base Dockerfile
+    cp Dockerfile.base "$TEMP_DIR/Dockerfile"
+    
+    # Insert language installations if any were selected
+    if [[ -n "$SELECTED_INSTALLATIONS" ]]; then
+        # Create a temporary file with the installations
+        echo -e "$SELECTED_INSTALLATIONS" > "$TEMP_DIR/installations.txt"
+        
+        # Replace placeholder with installations
+        sed -i.bak "/# LANGUAGE_INSTALLATIONS_PLACEHOLDER/r $TEMP_DIR/installations.txt" "$TEMP_DIR/Dockerfile"
+        sed -i.bak "/# LANGUAGE_INSTALLATIONS_PLACEHOLDER/d" "$TEMP_DIR/Dockerfile"
+        
+        # Clean up
+        rm -f "$TEMP_DIR/Dockerfile.bak" "$TEMP_DIR/installations.txt"
+    else
+        # Just remove the placeholder
+        sed -i.bak "/# LANGUAGE_INSTALLATIONS_PLACEHOLDER/d" "$TEMP_DIR/Dockerfile"
+        rm -f "$TEMP_DIR/Dockerfile.bak"
+    fi
+}
+
+# Check if languages.conf exists
+if [[ ! -f "$LANGUAGES_CONFIG" ]]; then
+    echo -e "${RED}Error: $LANGUAGES_CONFIG not found${NC}"
+    echo "Please ensure languages.conf is in the project directory"
     exit 1
 fi
 
@@ -52,11 +219,22 @@ if [ "$1" == "--clean" ] || [ "$1" == "-c" ]; then
     kubectl delete deployment claude-code -n ${NAMESPACE} --ignore-not-found=true
     echo -e "${YELLOW}Removing previous Docker image...${NC}"
     docker rmi ${IMAGE_NAME}:${IMAGE_TAG} || true
+    echo -e "${YELLOW}Removing temporary build directory...${NC}"
+    rm -rf "$TEMP_DIR"
 fi
+
+# Skip language selection if --no-select flag is provided
+if [ "$1" != "--no-select" ] && [ "$2" != "--no-select" ]; then
+    select_languages
+fi
+
+# Create custom Dockerfile
+echo -e "${YELLOW}Creating custom Dockerfile...${NC}"
+create_custom_dockerfile
 
 # Build the Docker image
 echo -e "${YELLOW}Building Docker image...${NC}"
-docker build -t ${IMAGE_NAME}:${IMAGE_TAG} .
+docker build -t ${IMAGE_NAME}:${IMAGE_TAG} -f "$TEMP_DIR/Dockerfile" .
 
 # Load the image into colima's containerd
 echo -e "${YELLOW}Loading image into Colima...${NC}"
@@ -86,3 +264,7 @@ echo -e "${YELLOW}kubectl exec -it -n ${NAMESPACE} ${POD_NAME} -- bash${NC}"
 echo -e "\nOnce connected, you can start Claude Code with:"
 echo -e "${YELLOW}cd /home/claude/workspace${NC}"
 echo -e "${YELLOW}claude${NC}"
+
+# Clean up temp directory
+echo -e "\n${YELLOW}Cleaning up temporary files...${NC}"
+rm -rf "$TEMP_DIR"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,15 @@ set -e
 # Ensure PATH includes npm global binaries
 export PATH="$PATH:/usr/local/bin:/usr/lib/node_modules/.bin"
 
+# Source all profile scripts to load language paths
+if [ -d /etc/profile.d ]; then
+    for i in /etc/profile.d/*.sh; do
+        if [ -r $i ]; then
+            . $i
+        fi
+    done
+fi
+
 # Create config directory if it doesn't exist
 CONFIG_DIR="/home/claude/.config/claude-code"
 mkdir -p "$CONFIG_DIR"

--- a/languages.conf
+++ b/languages.conf
@@ -1,0 +1,38 @@
+# Language installation configurations
+# Format: LANGUAGE_NAME|DISPLAY_NAME|INSTALLATION_COMMANDS
+
+# Python versions
+# Note: Ubuntu 22.04 comes with Python 3.10 by default
+PYTHON_3_9|Python 3.9|RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y python3.9 python3.9-venv python3.9-dev && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 && update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
+PYTHON_3_11|Python 3.11|RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y python3.11 python3.11-venv python3.11-dev && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+PYTHON_3_12|Python 3.12|RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y python3.12 python3.12-venv python3.12-dev && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+
+# Rust
+RUST_LATEST|Rust (latest)|RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo 'source $HOME/.cargo/env' >> /etc/profile.d/rust.sh && /root/.cargo/bin/rustup default stable && echo 'export PATH=/root/.cargo/bin:$PATH' >> /etc/profile
+RUST_NIGHTLY|Rust (nightly)|RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo 'source $HOME/.cargo/env' >> /etc/profile.d/rust.sh && /root/.cargo/bin/rustup default nightly && echo 'export PATH=/root/.cargo/bin:$PATH' >> /etc/profile
+
+# Go versions
+GO_1_21|Go 1.21|RUN wget -q https://go.dev/dl/go1.21.linux-arm64.tar.gz && tar -C /usr/local -xzf go1.21.linux-arm64.tar.gz && rm go1.21.linux-arm64.tar.gz && echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
+GO_1_22|Go 1.22|RUN wget -q https://go.dev/dl/go1.22.linux-arm64.tar.gz && tar -C /usr/local -xzf go1.22.linux-arm64.tar.gz && rm go1.22.linux-arm64.tar.gz && echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
+
+# Ruby versions
+RUBY_3_2|Ruby 3.2|RUN apt-get update && apt-get install -y ruby-full ruby-dev build-essential
+RUBY_3_3|Ruby 3.3 (via rbenv)|RUN apt-get update && apt-get install -y rbenv ruby-build && rbenv install 3.3.0 && rbenv global 3.3.0
+
+# Java versions
+JAVA_11|Java 11 (OpenJDK)|RUN apt-get update && apt-get install -y openjdk-11-jdk
+JAVA_17|Java 17 (OpenJDK)|RUN apt-get update && apt-get install -y openjdk-17-jdk
+JAVA_21|Java 21 (OpenJDK)|RUN apt-get update && apt-get install -y openjdk-21-jdk
+
+# .NET
+DOTNET_6|.NET 6.0|RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-6.0
+DOTNET_8|.NET 8.0|RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-8.0
+
+# PHP
+PHP_8_2|PHP 8.2|RUN apt-get update && apt-get install -y php8.2 php8.2-cli php8.2-common php8.2-curl php8.2-mbstring php8.2-xml php8.2-zip
+PHP_8_3|PHP 8.3|RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:ondrej/php && apt-get update && apt-get install -y php8.3 php8.3-cli php8.3-common php8.3-curl php8.3-mbstring php8.3-xml php8.3-zip
+
+# Other languages
+ELIXIR_LATEST|Elixir (latest with Erlang)|RUN apt-get update && apt-get install -y erlang elixir
+KOTLIN_LATEST|Kotlin (latest)|RUN apt-get update && apt-get install -y zip unzip && cd /tmp && wget https://github.com/JetBrains/kotlin/releases/download/v1.9.22/kotlin-compiler-1.9.22.zip && unzip kotlin-compiler-1.9.22.zip && mv kotlinc /opt/kotlin && rm kotlin-compiler-1.9.22.zip && echo 'export PATH=$PATH:/opt/kotlin/bin' >> /etc/profile.d/kotlin.sh
+SWIFT_5_9|Swift 5.9|RUN apt-get update && apt-get install -y binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev && wget https://download.swift.org/swift-5.9-release/ubuntu2204-aarch64/swift-5.9-RELEASE/swift-5.9-RELEASE-ubuntu22.04-aarch64.tar.gz && tar xzf swift-5.9-RELEASE-ubuntu22.04-aarch64.tar.gz && mv swift-5.9-RELEASE-ubuntu22.04-aarch64 /usr/share/swift && echo 'export PATH=/usr/share/swift/usr/bin:$PATH' >> /etc/profile.d/swift.sh && rm swift-5.9-RELEASE-ubuntu22.04-aarch64.tar.gz


### PR DESCRIPTION
Implement dynamic language installation system that allows users to optionally include additional programming languages in their Claude Code containers at build time.

Changes:
- Add interactive menu in build-and-deploy.sh for language selection
  - Arrow keys/j/k for navigation
  - Space to toggle selection
  - Enter to confirm
  - q to quit
- Create languages.conf configuration file with installable languages:
  - Python (3.9, 3.11, 3.12)
  - Rust (stable, nightly)
  - Go (1.21, 1.22)
  - Ruby (3.2, 3.3)
  - Java (OpenJDK 11, 17, 21)
  - .NET (6.0, 8.0)
  - PHP (8.2, 8.3)
  - Elixir, Kotlin, Swift
- Rename Dockerfile to Dockerfile.base with placeholder for languages
- Generate temporary Dockerfile in .build-temp/ directory
- Add .gitignore to exclude temporary build files
- Update entrypoint.sh to source profile scripts for language paths
- Add --no-select flag to skip language selection
- Support both python and python3 commands
- Ensure ARM64 compatibility for Apple Silicon

The system maintains backwards compatibility while providing flexibility for users to customize their development environment without modifying the core project files.