### PR TITLE
feat: Add Filebrowser as built-in sidecar for web-based file management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,4 @@
-### Customizing Language Options
-
-To add or modify available languages, edit the `languages.conf` file. The format is:
-```
-LANGUAGE_ID|Display Name|Installation Commands
-```
-
-For example:
-```
-PYTHON_3_13|Python 3.13|RUN apt-get update && apt-get install -y python3.13
-```
-
-The installation commands should be valid Dockerfile RUN instructions.## Features
-
-- **Containerized Claude Code**: Run Anthropic's AI coding assistant in an isolated Kubernetes environment
-- **Language Selection**: Optionally include additional programming languages and tools in your container
-- **Persistent Storage**: Configuration and workspace data persist across container restarts
-- **Security**: Runs as non-root user with proper isolation
-- **Easy Deployment**: Single script to build and deploy
-
-## Language Support
-
-The build script includes an interactive language selection menu. When you run the build script:
-
-1. The screen will clear and show a list of available languages
-2. Use **↑/↓ arrow keys** or **j/k** to move the cursor
-3. Press **SPACE** to select/deselect a language (selected items show ✓)
-4. Press **ENTER** to confirm your selections and continue
-5. Press **q** to quit without building
-
-Available languages include:
-
-- **Python**: 3.10, 3.11, 3.12
-- **Rust**: Latest stable, Nightly
-- **Go**: 1.21, 1.22
-- **Ruby**: 3.2, 3.3 (via rbenv)
-- **Java**: OpenJDK 11, 17, 21
-- **.NET**: 6.0, 8.0
-- **PHP**: 8.2, 8.3
-- **And more**: Elixir, Kotlin, Swift
-
-To add more languages, edit the `languages.conf` file.# Claude Code in Kubernetes
+# Claude Code in Kubernetes
 
 This project provides a containerized version of Claude Code running in Kubernetes, allowing you to use Anthropic's AI coding assistant in an isolated environment rather than directly on your host OS.
 
@@ -52,11 +11,13 @@ claude-code-k8s/
 ├── languages.conf          # Language installation configurations
 ├── entrypoint.sh           # Container startup script
 ├── build-and-deploy.sh     # Helper script for building and deploying
+├── access-filebrowser.sh   # Convenience script for accessing the file manager
 ├── .gitignore              # Git ignore file
 ├── kubernetes/
 │   ├── namespace.yaml      # Kubernetes namespace definition
 │   ├── pvc.yaml            # Persistent volume claims for configuration and workspace
-│   └── deployment.yaml     # Deployment configuration
+│   ├── deployment.yaml     # Deployment configuration (includes Filebrowser)
+│   └── nexus-config.yaml   # Nexus proxy configuration (if using Nexus)
 └── README.md               # This documentation
 ```
 
@@ -173,11 +134,84 @@ When you start Claude Code for the first time, you'll be prompted to authenticat
    - Alternatively, you can use an Anthropic API key
    - This is obtained from your Anthropic Console account
 
+## Features
+
+- **Containerized Claude Code**: Run Anthropic's AI coding assistant in an isolated Kubernetes environment
+- **Web-based File Manager**: Built-in Filebrowser for easy file uploads/downloads through a web UI
+- **Language Selection**: Optionally include additional programming languages and tools in your container
+- **Persistent Storage**: Configuration and workspace data persist across container restarts
+- **Security**: Runs as non-root user with proper isolation
+- **Easy Deployment**: Single script to build and deploy
+
+## Language Support
+
+The build script includes an interactive language selection menu. When you run the build script:
+
+1. The screen will clear and show a list of available languages
+2. Use **↑/↓ arrow keys** or **j/k** to move the cursor
+3. Press **SPACE** to select/deselect a language (selected items show ✓)
+4. Press **ENTER** to confirm your selections and continue
+5. Press **q** to quit without building
+
+Available languages include:
+
+- **Python**: 3.10, 3.11, 3.12
+- **Rust**: Latest stable, Nightly
+- **Go**: 1.21, 1.22
+- **Ruby**: 3.2, 3.3 (via rbenv)
+- **Java**: OpenJDK 11, 17, 21
+- **.NET**: 6.0, 8.0
+- **PHP**: 8.2, 8.3
+- **And more**: Elixir, Kotlin, Swift
+
+To add more languages, edit the `languages.conf` file.
+
+### Customizing Language Options
+
+To add or modify available languages, edit the `languages.conf` file. The format is:
+```
+LANGUAGE_ID|Display Name|Installation Commands
+```
+
+For example:
+```
+PYTHON_3_13|Python 3.13|RUN apt-get update && apt-get install -y python3.13
+```
+
+The installation commands should be valid Dockerfile RUN instructions.
+
 ## Working with Files
 
-### Copying Files to/from the Container
+### Web-based File Manager (Filebrowser)
 
-Use `kubectl cp` to transfer files between your host and the container:
+Every Claude Code deployment includes Filebrowser, a web-based file manager for easy file operations.
+
+#### Accessing Filebrowser
+
+1. Start port forwarding:
+   ```bash
+   kubectl port-forward -n claude-code service/claude-code 8090:8090
+   ```
+
+2. Open in your browser: [http://localhost:8090](http://localhost:8090)
+
+3. Login with default credentials:
+   - Username: `admin`
+   - Password: `admin`
+   - **⚠️ Important**: Change the password after first login!
+
+#### Filebrowser Features
+
+- **Upload**: Drag & drop multiple files or entire folders
+- **Download**: Select files/folders and download as ZIP
+- **Edit**: Built-in text editor with syntax highlighting
+- **Search**: Find files quickly across your workspace
+- **Preview**: View images, PDFs, and other file types
+- **Terminal**: Execute commands directly (if enabled)
+
+### Command Line File Transfer
+
+You can still use `kubectl cp` for command-line file transfers:
 
 ```bash
 # Copy from local to container

--- a/access-filebrowser.sh
+++ b/access-filebrowser.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Convenience script to access Claude Code's Filebrowser
+
+set -e
+
+# Configuration
+NAMESPACE="claude-code"
+SERVICE_NAME="claude-code"
+LOCAL_PORT="${FILEBROWSER_PORT:-8090}"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}=== Claude Code Filebrowser Access ===${NC}"
+
+# Check if kubectl is available
+if ! command -v kubectl &> /dev/null; then
+    echo -e "${RED}Error: kubectl is not installed or not in PATH${NC}"
+    exit 1
+fi
+
+# Check if deployment exists
+if ! kubectl get deployment claude-code -n ${NAMESPACE} &> /dev/null; then
+    echo -e "${RED}Error: Claude Code deployment not found${NC}"
+    echo -e "Please deploy Claude Code first using ./build-and-deploy.sh"
+    exit 1
+fi
+
+# Check if port is already in use
+if lsof -i :${LOCAL_PORT} &> /dev/null; then
+    echo -e "${YELLOW}Port ${LOCAL_PORT} is already in use${NC}"
+    echo -e "Filebrowser may already be accessible at: ${BLUE}http://localhost:${LOCAL_PORT}${NC}"
+    echo -n "Kill existing process and restart? (y/N): "
+    read -r RESTART
+    
+    if [[ "$RESTART" =~ ^[Yy]$ ]]; then
+        echo -e "${YELLOW}Stopping existing process...${NC}"
+        lsof -ti :${LOCAL_PORT} | xargs kill -9 2>/dev/null || true
+        sleep 2
+    else
+        exit 0
+    fi
+fi
+
+# Start port forwarding
+echo -e "${YELLOW}Starting port forwarding...${NC}"
+echo -e "${GREEN}Filebrowser will be available at: ${BLUE}http://localhost:${LOCAL_PORT}${NC}"
+echo -e "\nDefault credentials:"
+echo -e "  Username: ${YELLOW}admin${NC}"
+echo -e "  Password: ${YELLOW}admin${NC}"
+echo -e "\n${YELLOW}Press Ctrl+C to stop${NC}\n"
+
+# Open browser if available
+if command -v xdg-open &> /dev/null; then
+    sleep 2 && xdg-open "http://localhost:${LOCAL_PORT}" &
+elif command -v open &> /dev/null; then
+    sleep 2 && open "http://localhost:${LOCAL_PORT}" &
+fi
+
+# Start port forwarding in foreground
+kubectl port-forward -n ${NAMESPACE} service/${SERVICE_NAME} ${LOCAL_PORT}:8090

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: claude-code
     spec:
       containers:
+      # Main Claude Code container
       - name: claude-code
         image: claude-code:latest
         imagePullPolicy: IfNotPresent
@@ -32,6 +33,39 @@ spec:
           limits:
             memory: "1Gi"
             cpu: "500m"
+      
+      # Filebrowser sidecar for easy file management
+      - name: filebrowser
+        image: filebrowser/filebrowser:latest
+        ports:
+        - containerPort: 8090
+          name: filebrowser
+        volumeMounts:
+        - name: workspace-volume
+          mountPath: /srv
+        - name: filebrowser-config
+          mountPath: /config
+        - name: filebrowser-db
+          mountPath: /database
+        env:
+        - name: FB_DATABASE
+          value: /database/filebrowser.db
+        - name: FB_CONFIG
+          value: /config/settings.json
+        - name: FB_ROOT
+          value: /srv
+        - name: FB_LOG
+          value: stdout
+        - name: FB_PORT
+          value: "8090"
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+      
       volumes:
       - name: config-volume
         persistentVolumeClaim:
@@ -39,3 +73,59 @@ spec:
       - name: workspace-volume
         persistentVolumeClaim:
           claimName: claude-code-workspace-pvc
+      - name: filebrowser-config
+        configMap:
+          name: filebrowser-config
+      - name: filebrowser-db
+        emptyDir: {}
+---
+# Service to expose Filebrowser
+apiVersion: v1
+kind: Service
+metadata:
+  name: claude-code
+  namespace: claude-code
+spec:
+  selector:
+    app: claude-code
+  ports:
+  - name: filebrowser
+    port: 8090
+    targetPort: 8090
+  type: ClusterIP
+---
+# ConfigMap for Filebrowser settings
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebrowser-config
+  namespace: claude-code
+data:
+  settings.json: |
+    {
+      "port": 8090,
+      "baseURL": "",
+      "address": "0.0.0.0",
+      "log": "stdout",
+      "database": "/database/filebrowser.db",
+      "root": "/srv",
+      "username": "admin",
+      "password": "admin",
+      "branding": {
+        "name": "Claude Code Workspace",
+        "disableExternal": false,
+        "color": "#2979ff"
+      },
+      "authMethod": "password",
+      "commands": {
+        "after_save": [],
+        "before_save": []
+      },
+      "shell": ["/bin/bash", "-c"],
+      "allowEdit": true,
+      "allowNew": true,
+      "disablePreviewResize": false,
+      "disableExec": false,
+      "disableUsedPercentage": false,
+      "hideDotfiles": false
+    }


### PR DESCRIPTION
BREAKING CHANGE: Filebrowser is now included by default in all deployments

- Add Filebrowser sidecar container to main deployment.yaml
  - Runs on port 8090 to avoid conflicts with common dev ports
  - Shares workspace volume with Claude Code container
  - Includes web UI for file upload/download/edit operations

- Remove optional Filebrowser setup from build script
  - No longer prompts user about file manager setup
  - Simplified deployment process with fewer decisions

- Add convenience script access-filebrowser.sh
  - One-command access to file manager
  - Auto-opens browser on supported platforms
  - Handles port conflicts gracefully

- Update documentation
  - List web-based file manager as core feature
  - Add Filebrowser access instructions to README
  - Update deployment completion messages

- Include Filebrowser in Nexus-aware deployments
  - Consistent experience regardless of proxy configuration
  - Same port and access method across all deployment types

This change significantly improves the user experience by eliminating the need for complex kubectl cp commands. Users can now easily manage files through a modern web interface with drag-and-drop support, multi-file operations, and built-in text editing.

Default credentials: admin/admin (must be changed on first login)
Access via: kubectl port-forward -n claude-code service/claude-code 8090:8090