### PR TITLE
refactor: eliminate tech debt and unify K8s deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This project provides a containerized version of Claude Code running in Kubernet
 
 ```
 claude-code-k8s/
-├── Dockerfile              # Container definition for Claude Code (deprecated - use Dockerfile.base)
 ├── Dockerfile.base         # Base container definition
 ├── languages.conf          # Language installation configurations
 ├── entrypoint.sh           # Container startup script

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -612,99 +612,7 @@ create_custom_dockerfile() {
     fi
 }
 
-# Function to create Nexus-aware deployment (compressed)
-create_nexus_deployment() {
-    log "Creating Nexus-aware Kubernetes deployment..."
-    kubectl apply -f kubernetes/nexus-config.yaml
-    
-    cat > "$TEMP_DIR/deployment.yaml" << 'EOF'
-apiVersion: apps/v1
-kind: Deployment
-metadata: {name: claude-code, namespace: claude-code, labels: {app: claude-code}}
-spec:
-  replicas: 1
-  selector: {matchLabels: {app: claude-code}}
-  template:
-    metadata: {labels: {app: claude-code}}
-    spec:
-      containers:
-      - name: claude-code
-        image: claude-code:latest
-        imagePullPolicy: IfNotPresent
-        command: ["sleep", "infinity"]
-        volumeMounts:
-        - {name: config-volume, mountPath: /home/claude/.config/claude-code}
-        - {name: workspace-volume, mountPath: /home/claude/workspace}
-        - {name: cargo-dir, mountPath: /home/claude/.cargo}
-        - {name: cargo-config, mountPath: /home/claude/.cargo/config.toml, subPath: cargo-config.toml}
-        - {name: pip-config, mountPath: /home/claude/.config/pip/pip.conf, subPath: pip.conf}
-        - {name: npm-config, mountPath: /home/claude/.npmrc, subPath: npmrc}
-        env:
-        - {name: PIP_INDEX_URL, value: "http://host.lima.internal:8081/repository/pypi-proxy/simple/"}
-        - {name: PIP_TRUSTED_HOST, value: "host.lima.internal"}
-        - {name: NPM_CONFIG_REGISTRY, value: "http://host.lima.internal:8081/repository/npm-proxy/"}
-        - {name: GOPROXY, value: "http://host.lima.internal:8081/repository/go-proxy/"}
-        - {name: CARGO_HOME, value: "/home/claude/.cargo"}
-        - {name: CARGO_NET_GIT_FETCH_WITH_CLI, value: "true"}
-        - {name: CARGO_HTTP_CHECK_REVOKE, value: "false"}
-        - {name: CARGO_HTTP_TIMEOUT, value: "60"}
-        - {name: HTTP_PROXY, value: "http://host.lima.internal:8081"}
-        - {name: HTTPS_PROXY, value: "http://host.lima.internal:8081"}
-        - {name: NO_PROXY, value: "localhost,127.0.0.1,.svc,.cluster.local"}
-        - {name: no_proxy, value: "localhost,127.0.0.1,.svc,.cluster.local"}
-        resources: {requests: {memory: "256Mi", cpu: "100m"}, limits: {memory: "1Gi", cpu: "500m"}}
-      - name: filebrowser
-        image: filebrowser/filebrowser:latest
-        ports: [{containerPort: 8090, name: filebrowser}]
-        volumeMounts:
-        - {name: workspace-volume, mountPath: /srv}
-        - {name: filebrowser-config, mountPath: /config}
-        - {name: filebrowser-db, mountPath: /database}
-        env:
-        - {name: FB_DATABASE, value: /database/filebrowser.db}
-        - {name: FB_CONFIG, value: /config/settings.json}
-        - {name: FB_ROOT, value: /srv}
-        - {name: FB_LOG, value: stdout}
-        - {name: FB_PORT, value: "8090"}
-        resources: {requests: {memory: "64Mi", cpu: "50m"}, limits: {memory: "256Mi", cpu: "200m"}}
-      volumes:
-      - {name: config-volume, persistentVolumeClaim: {claimName: claude-code-config-pvc}}
-      - {name: workspace-volume, persistentVolumeClaim: {claimName: claude-code-workspace-pvc}}
-      - {name: cargo-dir, emptyDir: {}}
-      - {name: filebrowser-config, configMap: {name: filebrowser-config}}
-      - {name: filebrowser-db, emptyDir: {}}
-      - name: pip-config
-        configMap: {name: nexus-proxy-config, items: [{key: pip.conf, path: pip.conf}], defaultMode: 0644}
-      - name: npm-config
-        configMap: {name: nexus-proxy-config, items: [{key: npmrc, path: npmrc}], defaultMode: 0644}
-      - name: cargo-config
-        configMap: {name: nexus-proxy-config, items: [{key: cargo-config.toml, path: cargo-config.toml}], defaultMode: 0644}
----
-apiVersion: v1
-kind: Service
-metadata: {name: claude-code, namespace: claude-code}
-spec:
-  selector: {app: claude-code}
-  ports: [{name: filebrowser, port: 8090, targetPort: 8090}]
-  type: ClusterIP
----
-apiVersion: v1
-kind: ConfigMap
-metadata: {name: filebrowser-config, namespace: claude-code}
-data:
-  settings.json: |
-    {
-      "port": 8090, "baseURL": "", "address": "0.0.0.0", "log": "stdout",
-      "database": "/database/filebrowser.db", "root": "/srv",
-      "username": "admin", "password": "admin",
-      "branding": {"name": "Claude Code Workspace", "disableExternal": false, "color": "#2979ff"},
-      "authMethod": "password", "commands": {"after_save": [], "before_save": []},
-      "shell": ["/bin/bash", "-c"], "allowEdit": true, "allowNew": true,
-      "disablePreviewResize": false, "disableExec": false,
-      "disableUsedPercentage": false, "hideDotfiles": false
-    }
-EOF
-}
+# No longer need this function - deployment.yaml handles both scenarios
 
 # Main execution
 main() {
@@ -762,12 +670,14 @@ main() {
     kubectl apply -f kubernetes/namespace.yaml
     kubectl apply -f kubernetes/pvc.yaml
     
+    # Apply Nexus configuration if available
     if [[ "$NEXUS_AVAILABLE" = true ]]; then
-        create_nexus_deployment
-        kubectl apply -f "$TEMP_DIR/deployment.yaml"
-    else
-        kubectl apply -f kubernetes/deployment.yaml
+        log "Applying Nexus proxy configuration..."
+        kubectl apply -f kubernetes/nexus-config.yaml
     fi
+    
+    # Apply the unified deployment
+    kubectl apply -f kubernetes/deployment.yaml
     
     log "Waiting for deployment to be ready..."
     kubectl wait --for=condition=available --timeout=120s deployment/claude-code -n ${NAMESPACE}

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -26,6 +26,88 @@ spec:
           mountPath: /home/claude/.config/claude-code
         - name: workspace-volume
           mountPath: /home/claude/workspace
+        # Nexus-specific mounts (will fail gracefully if ConfigMap doesn't exist)
+        - name: cargo-dir
+          mountPath: /home/claude/.cargo
+        - name: cargo-config
+          mountPath: /home/claude/.cargo/config.toml
+          subPath: cargo-config.toml
+        - name: pip-config
+          mountPath: /home/claude/.config/pip/pip.conf
+          subPath: pip.conf
+        - name: npm-config
+          mountPath: /home/claude/.npmrc
+          subPath: npmrc
+        env:
+        # These environment variables will be populated from ConfigMap if it exists
+        - name: PIP_INDEX_URL
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: PIP_INDEX_URL
+              optional: true
+        - name: PIP_TRUSTED_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: PIP_TRUSTED_HOST
+              optional: true
+        - name: NPM_CONFIG_REGISTRY
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: NPM_CONFIG_REGISTRY
+              optional: true
+        - name: GOPROXY
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: GOPROXY
+              optional: true
+        - name: CARGO_HOME
+          value: "/home/claude/.cargo"
+        - name: CARGO_NET_GIT_FETCH_WITH_CLI
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: CARGO_NET_GIT_FETCH_WITH_CLI
+              optional: true
+        - name: CARGO_HTTP_CHECK_REVOKE
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: CARGO_HTTP_CHECK_REVOKE
+              optional: true
+        - name: CARGO_HTTP_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: CARGO_HTTP_TIMEOUT
+              optional: true
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: HTTP_PROXY
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: HTTPS_PROXY
+              optional: true
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: NO_PROXY
+              optional: true
+        - name: no_proxy
+          valueFrom:
+            configMapKeyRef:
+              name: nexus-env-config
+              key: no_proxy
+              optional: true
         resources:
           requests:
             memory: "256Mi"
@@ -73,11 +155,38 @@ spec:
       - name: workspace-volume
         persistentVolumeClaim:
           claimName: claude-code-workspace-pvc
+      - name: cargo-dir
+        emptyDir: {}
       - name: filebrowser-config
         configMap:
           name: filebrowser-config
       - name: filebrowser-db
         emptyDir: {}
+      # Nexus-specific config volumes (optional: true means they won't fail if ConfigMap doesn't exist)
+      - name: pip-config
+        configMap:
+          name: nexus-proxy-config
+          items:
+          - key: pip.conf
+            path: pip.conf
+          defaultMode: 0644
+          optional: true
+      - name: npm-config
+        configMap:
+          name: nexus-proxy-config
+          items:
+          - key: npmrc
+            path: npmrc
+          defaultMode: 0644
+          optional: true
+      - name: cargo-config
+        configMap:
+          name: nexus-proxy-config
+          items:
+          - key: cargo-config.toml
+            path: cargo-config.toml
+          defaultMode: 0644
+          optional: true
 ---
 # Service to expose Filebrowser
 apiVersion: v1

--- a/kubernetes/nexus-config.yaml
+++ b/kubernetes/nexus-config.yaml
@@ -18,3 +18,22 @@ data:
     
     [source.nexus]
     registry = "sparse+http://host.lima.internal:8081/repository/cargo-crates-io/"
+---
+# Environment variables for Nexus configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nexus-env-config
+  namespace: claude-code
+data:
+  PIP_INDEX_URL: "http://host.lima.internal:8081/repository/pypi-proxy/simple/"
+  PIP_TRUSTED_HOST: "host.lima.internal"
+  NPM_CONFIG_REGISTRY: "http://host.lima.internal:8081/repository/npm-proxy/"
+  GOPROXY: "http://host.lima.internal:8081/repository/go-proxy/"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  CARGO_HTTP_CHECK_REVOKE: "false"
+  CARGO_HTTP_TIMEOUT: "60"
+  HTTP_PROXY: "http://host.lima.internal:8081"
+  HTTPS_PROXY: "http://host.lima.internal:8081"
+  NO_PROXY: "localhost,127.0.0.1,.svc,.cluster.local"
+  no_proxy: "localhost,127.0.0.1,.svc,.cluster.local"


### PR DESCRIPTION
BREAKING CHANGE: Nexus proxy configuration now requires both nexus-proxy-config and nexus-env-config ConfigMaps to be applied together.

Major improvements:
- Unified deployment.yaml now handles both Nexus and non-Nexus scenarios
  - Uses Kubernetes optional ConfigMap references instead of generating YAML
  - Eliminates ~100 lines of duplicate inline YAML from build script
  - Single source of truth for deployment configuration

- Optimized entrypoint.sh to prevent duplicate configuration entries
  - Added add_if_not_exists() function to avoid duplicate .bashrc entries
  - Consolidated directory creation and ownership operations
  - Fixed issue where PATH could grow on container restarts

- Enhanced Nexus configuration structure
  - Split into nexus-proxy-config (files) and nexus-env-config (env vars)
  - Cleaner separation of concerns
  - All ConfigMap mounts and env vars are optional

- Removed create_nexus_deployment() function from build-and-deploy.sh
  - Simplified deployment logic
  - Better maintainability

- Updated README.md to remove reference to deprecated Dockerfile

These changes significantly reduce maintenance burden and make the deployment more reliable and Kubernetes-native. The deployment process is now identical whether Nexus is configured or not - Kubernetes handles the differences transparently.