### PR TITLE
feat: add Nexus APT proxy support for Ubuntu package caching

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,10 +8,29 @@ ARG PIP_INDEX_URL=""
 ARG PIP_TRUSTED_HOST=""
 ARG NPM_REGISTRY=""
 ARG GOPROXY=""
+ARG USE_NEXUS_APT=""
+ARG NEXUS_APT_URL=""
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TARGETARCH=${TARGETARCH}
+
+# Configure APT to use Nexus if enabled
+RUN if [ -n "$USE_NEXUS_APT" ] && [ -n "$NEXUS_APT_URL" ]; then \
+        echo "Configuring APT to use Nexus proxy..." && \
+        # Backup original sources.list \
+        cp /etc/apt/sources.list /etc/apt/sources.list.backup && \
+        # Clear the sources.list \
+        echo "" > /etc/apt/sources.list && \
+        # Add Nexus repositories \
+        echo "deb ${NEXUS_APT_URL}/repository/ubuntu-main/ jammy main restricted universe multiverse" >> /etc/apt/sources.list && \
+        echo "deb ${NEXUS_APT_URL}/repository/ubuntu-updates/ jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
+        echo "deb ${NEXUS_APT_URL}/repository/ubuntu-security/ jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
+        # Since we're using HTTP, we need to allow insecure repositories \
+        echo 'Acquire::AllowInsecureRepositories "true";' > /etc/apt/apt.conf.d/99nexus && \
+        echo 'Acquire::AllowDowngradeToInsecureRepositories "true";' >> /etc/apt/apt.conf.d/99nexus && \
+        echo "✓ Configured APT to use Nexus proxy" ; \
+    fi
 
 # Configure package managers if proxy URLs are provided
 RUN if [ -n "$PIP_INDEX_URL" ]; then \

--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -826,7 +826,7 @@ main() {
     if check_nexus; then
         NEXUS_AVAILABLE=true
         export DOCKER_BUILDKIT=0
-        export NEXUS_BUILD_ARGS="--build-arg PIP_INDEX_URL=http://host.lima.internal:8081/repository/pypi-proxy/simple/ --build-arg PIP_TRUSTED_HOST=host.lima.internal --build-arg NPM_REGISTRY=http://host.lima.internal:8081/repository/npm-proxy/ --build-arg GOPROXY=http://host.lima.internal:8081/repository/go-proxy/"
+        export NEXUS_BUILD_ARGS="--build-arg PIP_INDEX_URL=http://host.lima.internal:8081/repository/pypi-proxy/simple/ --build-arg PIP_TRUSTED_HOST=host.lima.internal --build-arg NPM_REGISTRY=http://host.lima.internal:8081/repository/npm-proxy/ --build-arg GOPROXY=http://host.lima.internal:8081/repository/go-proxy/ --build-arg USE_NEXUS_APT=true --build-arg NEXUS_APT_URL=http://host.lima.internal:8081"
         success "Nexus proxy will be used for package downloads"
     else
         log "Nexus not detected, using default package repositories"


### PR DESCRIPTION
- Add APT proxy configuration to Dockerfile.base with build args
- Update build-and-deploy.sh to pass APT proxy args when Nexus detected
- Configure Docker builds to use Nexus for apt-get operations
- Add USE_NEXUS_APT and NEXUS_APT_URL build arguments

This enables all Ubuntu package downloads during Docker builds to be proxied through Nexus, reducing bandwidth usage and improving build performance through local caching.