### PR TITLE
fix: Add inject_files entries and remove hardcoded COPY commands for claude-code

### DIFF
--- a/components/agents/claude-code.yaml
+++ b/components/agents/claude-code.yaml
@@ -47,6 +47,21 @@ installation:
     - source: claude-code/settings.local.json.template
       destination: /tmp/claude-settings.local.json.template
       permissions: "644"
+    - source: commands/
+      destination: /tmp/claude-commands/
+      permissions: "755"
+    - source: agents/
+      destination: /tmp/claude-agents/
+      permissions: "755"
+    - source: hooks/
+      destination: /tmp/claude-hooks/
+      permissions: "755"
+    - source: scripts/
+      destination: /tmp/scripts/
+      permissions: "755"
+    - source: docs/
+      destination: /tmp/claude-docs/
+      permissions: "755"
 entrypoint_setup: |
   # Create Claude Code directories
   echo "Setting up Claude Code..."

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -212,11 +212,6 @@ RUN mkdir -p /tmp/work-scripts && \
     mkdir -p /var/run/work-queue && \
     chmod 755 /var/run/work-queue
 
-# Copy Claude commands and hooks (these should always exist after pre-build)
-# The claude-code-setup.sh script should ensure these directories exist
-COPY claude-commands /tmp/claude-commands/
-COPY claude-hooks /tmp/claude-hooks/
-
 # Set environment variables for runtime if proxies are configured
 ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ENV PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}


### PR DESCRIPTION
## Summary

Fixes Docker build failure caused by missing inject_files directory entries and legacy hardcoded COPY commands in Dockerfile.base.

## Problem

After PR #49 fixed the YAML indentation, the build was failing with:
```
Step 48/64 : COPY claude-commands /tmp/claude-commands/
COPY failed: file not found in build context or excluded by .dockerignore: stat claude-commands: file does not exist
```

## Root Cause

1. **Legacy COPY commands**: `docker/Dockerfile.base` lines 217-218 had hardcoded `COPY` commands for `claude-commands` and `claude-hooks` directories that don't exist in the build context
2. **Missing inject_files entries**: The pre-build script creates 5 directories (commands, agents, hooks, scripts, docs) but only 3 template files were listed in inject_files

## Changes

### docker/Dockerfile.base
- Removed lines 217-218: hardcoded `COPY claude-commands` and `COPY claude-hooks` commands
- These are legacy from before the component used inject_files mechanism
- Files are now properly handled through inject_files + entrypoint_setup

### components/agents/claude-code.yaml  
- Added inject_files entries for all directories created by pre-build script:
  - `commands/` → `/tmp/claude-commands/`
  - `agents/` → `/tmp/claude-agents/`
  - `hooks/` → `/tmp/claude-hooks/`
  - `scripts/` → `/tmp/scripts/`
  - `docs/` → `/tmp/claude-docs/`
- Total inject_files entries: 3 template files + 5 directories = 8 entries

## Test Plan

- [x] Verify YAML is valid: `yq . components/agents/claude-code.yaml`
- [x] Verify inject_files count: `yq '.installation.inject_files | length'` returns 8
- [ ] Build container image with claude-code selected
- [ ] Deploy and verify Claude Code files are properly installed
- [ ] Test autonomous development commands work correctly

## Related

- Fixes build failure introduced after PR #49 merge
- Completes the claude-code component fixes for v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)