### PR TITLE
fix: Remove incorrect path prefix from inject_files source paths

### DIFF
--- a/components/agents/claude-code.yaml
+++ b/components/agents/claude-code.yaml
@@ -38,13 +38,13 @@ installation:
     # Claude Code CLI will be installed via container initialization
     # No installation needed in Dockerfile - it's handled at runtime
   inject_files:
-    - source: claude-code/CLAUDE.md.template
+    - source: CLAUDE.md.template
       destination: /tmp/CLAUDE.md.template
       permissions: "644"
-    - source: claude-code/settings.json.template
+    - source: settings.json.template
       destination: /tmp/claude-settings.json.template
       permissions: "644"
-    - source: claude-code/settings.local.json.template
+    - source: settings.local.json.template
       destination: /tmp/claude-settings.local.json.template
       permissions: "644"
     - source: commands/


### PR DESCRIPTION
## Summary

Fixes Docker build failure caused by incorrect path prefixes in `inject_files` source paths.

## Problem

After PR #50 was merged, the build was still failing with:
```
Step 57/73 : COPY claude-code/CLAUDE.md.template /tmp/CLAUDE.md.template
COPY failed: file not found in build context or excluded by .dockerignore: stat claude-code/CLAUDE.md.template: file does not exist
```

## Root Cause

The `inject_files` source paths were incorrectly prefixed with `claude-code/`, but the build system's `component_dir` variable already points to the `components/agents/claude-code` directory. 

When the build system tries to copy files, it constructs the path as `$component_dir/$source`, which resulted in:
- `components/agents/claude-code/claude-code/CLAUDE.md.template` ❌ (incorrect - doesn't exist)

Instead, it should be:
- `components/agents/claude-code/CLAUDE.md.template` ✅ (correct)

## Changes

Updated `components/agents/claude-code.yaml` inject_files source paths:

**Before:**
```yaml
- source: claude-code/CLAUDE.md.template
- source: claude-code/settings.json.template  
- source: claude-code/settings.local.json.template
```

**After:**
```yaml
- source: CLAUDE.md.template
- source: settings.json.template
- source: settings.local.json.template
```

This matches the pattern used by other components (e.g., `ai-kanban.yaml`) where source paths are relative to the component directory without the component name prefix.

## Test Plan

- [x] Verify YAML is valid: `yq . components/agents/claude-code.yaml`
- [ ] Build container image with claude-code selected - should succeed
- [ ] Verify files are copied to correct /tmp/ locations
- [ ] Deploy and test Claude Code functionality

## Related

- Follows up on PR #50
- Completes the inject_files configuration for claude-code component

🤖 Generated with [Claude Code](https://claude.com/claude-code)