### PR TITLE
fix: Remove redundant chmod causing container crash

### DIFF
--- a/components/agents/claude-code.yaml
+++ b/components/agents/claude-code.yaml
@@ -145,8 +145,6 @@ entrypoint_setup: |
     # Make hooks executable
     find /home/devuser/.claude/hooks -type f -name "*.sh" -exec chmod 755 {} \;
 
-    chmod 755 /home/devuser/.claude/hooks/*.sh
-
     echo "Created default hook scripts"
   fi
 


### PR DESCRIPTION
## Summary

Fixes container crash loop caused by a redundant `chmod` command in the Claude Code entrypoint_setup script.

## Problem

After PR #51 was merged, the container was crashing in a restart loop with the error:
```
Installing Claude Code hooks...
chmod: cannot access '/home/devuser/.claude/hooks/*.sh': No such file or directory
```

The pod events showed:
```
Warning  BackOff    11s (x4 over 39s)  kubelet  Back-off restarting failed container ai-devkit
```

## Root Cause

Line 148 in `entrypoint_setup` had a redundant glob-based chmod:
```bash
chmod 755 /home/devuser/.claude/hooks/*.sh
```

This command fails when the glob pattern `*.sh` doesn't match any files (i.e., when the hooks directory is empty or contains no `.sh` files). The failure causes the entrypoint script to exit with a non-zero status, triggering Kubernetes to restart the container.

## Fix

Removed the redundant `chmod` line because line 146 already handles this safely:
```bash
find /home/devuser/.claude/hooks -type f -name "*.sh" -exec chmod 755 {} \;
```

The `find` command is safe because:
- It doesn't fail when no files match the pattern
- It properly handles permissions for any number of files
- It's already present in the script, making the glob-based chmod redundant

## Changes

**components/agents/claude-code.yaml** (line 148):
```diff
  # Make hooks executable
  find /home/devuser/.claude/hooks -type f -name "*.sh" -exec chmod 755 {} \;
  
- chmod 755 /home/devuser/.claude/hooks/*.sh
-
  echo "Created default hook scripts"
```

## Test Plan

- [x] Verify YAML is valid: `yq . components/agents/claude-code.yaml`
- [ ] Build and deploy with claude-code component selected
- [ ] Verify container starts successfully without crash loop
- [ ] Check logs show "Created default hook scripts" message
- [ ] Verify Claude Code functionality works correctly

## Related

- Fixes crash introduced after PR #51 merge
- Completes the claude-code component fixes for v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)