### PR TITLE
fix: Restore Claude Code npm installation

### DIFF
--- a/components/agents/claude-code.yaml
+++ b/components/agents/claude-code.yaml
@@ -35,8 +35,25 @@ command_permissions:
   deny: []
 installation:
   dockerfile: |
-    # Claude Code CLI will be installed via container initialization
-    # No installation needed in Dockerfile - it's handled at runtime
+    # Claude Code requires Node.js to be installed first
+    # The build system should ensure nodejs-version components are installed before this
+
+    # Install additional utilities needed by journal scripts
+    RUN apt-get update && apt-get install -y \
+        uuid-runtime \
+        --no-install-recommends && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*
+
+    # Install Claude Code globally as root first
+    RUN export NPM_CONFIG_PREFIX=/home/devuser/.npm-global && \
+        export PATH="/home/devuser/.npm-global/bin:/usr/local/bin:${PATH}" && \
+        mkdir -p /home/devuser/.npm-global && \
+        chown -R devuser:devuser /home/devuser/.npm-global && \
+        npm install -g @anthropic-ai/claude-code && \
+        ls -la /home/devuser/.npm-global/bin/ && \
+        /home/devuser/.npm-global/bin/claude --version || (echo "Claude Code installation failed" && exit 1) && \
+        chown -R devuser:devuser /home/devuser/.npm-global
   inject_files:
     - source: CLAUDE.md.template
       destination: /tmp/CLAUDE.md.template


### PR DESCRIPTION
## Summary

Fixes the broken Claude Code component on the `develop` branch by restoring the npm installation commands that were accidentally removed in commit fb16883.

## Problem

The Claude Code component was completely non-functional on the `develop` branch:
- `claude --help` → command not found
- Empty workspace directory
- No Claude Code installation anywhere in the container

## Root Cause

In commit fb16883, the `installation.dockerfile` section was replaced with just a comment:
```yaml
# Claude Code CLI will be installed via container initialization
# No installation needed in Dockerfile - it's handled at runtime
```

However, **no runtime installation mechanism was ever implemented**. The `entrypoint_setup` section only copies configuration files—it never runs `npm install`.

## Solution

Restored the proper npm installation commands in `components/agents/claude-code.yaml`:
- Install `uuid-runtime` utilities needed by journal scripts
- Install `@anthropic-ai/claude-code` globally via npm
- Verify installation with `--version` check
- Rely on the build system's dependency ordering (topological sort) to ensure Node.js is installed first

## Build System Verification

Confirmed that the build system correctly:
✅ Sorts components by dependencies using topological sort  
✅ Processes Node.js before Claude Code (due to `requires: nodejs`)  
✅ Injects installation commands at `LANGUAGE_INSTALLATIONS_PLACEHOLDER`  
✅ Dynamically builds the Dockerfile in the build-temp directory

## Testing

After this fix, the Claude Code CLI should be properly installed and available in containers built from the `develop` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)