### PR TITLE
feat(gh-cli): improve installation and add automatic authentication

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -83,27 +83,16 @@ ENV LANGUAGE=en_US:en
 RUN wget -q -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq
 
-# Install GitHub CLI (gh) - handle both proxy and non-proxy scenarios
-RUN if [ -n "$USE_NEXUS_APT" ] && [ -n "$NEXUS_APT_URL" ]; then \
-        # When using Nexus, try to install from Ubuntu universe repo instead \
-        apt-get update && apt-get install -y gh 2>&1 | \
-        { grep -v "update-alternatives: warning: skip creation of .* because associated file .* doesn't exist" || true; } || \
-        # If that fails, download the binary directly \
-        (ARCH=$(dpkg --print-architecture) && \
-         GH_VERSION="2.40.1" && \
-         wget -q "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb" && \
-         dpkg -i "gh_${GH_VERSION}_linux_${ARCH}.deb" && \
-         rm "gh_${GH_VERSION}_linux_${ARCH}.deb") || \
-        echo "Warning: GitHub CLI installation failed"; \
-    else \
-        # Standard installation when not using proxy \
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-        chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-        apt-get update && \
-        apt-get install -y gh 2>&1 | \
-        { grep -v "update-alternatives: warning: skip creation of .* because associated file .* doesn't exist" || true; }; \
-    fi && \
+# Install GitHub CLI (gh) - using idiomatic installation method
+RUN mkdir -p -m 755 /etc/apt/keyrings && \
+    wget -nv -O /tmp/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg && \
+    cat /tmp/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
+    rm /tmp/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gh 2>&1 | \
+    { grep -v "update-alternatives: warning: skip creation of .* because associated file .* doesn't exist" || true; } && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/entrypoint.base.sh
+++ b/docker/entrypoint.base.sh
@@ -56,9 +56,21 @@ if [ -f /tmp/git-mounted/.git-credentials ]; then
     cp /tmp/git-mounted/.git-credentials /home/devuser/.git-credentials
     chown devuser:devuser /home/devuser/.git-credentials
     chmod 600 /home/devuser/.git-credentials
+
+    # Extract GitHub token from git-credentials and set as GH_TOKEN for automatic gh CLI authentication
+    # Format is: https://username:token@github.com
+    GITHUB_TOKEN=$(grep "github.com" /home/devuser/.git-credentials | sed -n 's|https://[^:]*:\([^@]*\)@github.com|\1|p' | head -1)
+    if [ -n "$GITHUB_TOKEN" ]; then
+        echo "Configuring GitHub CLI (gh) authentication via GH_TOKEN"
+        # Set for root user entrypoint scripts
+        export GH_TOKEN="$GITHUB_TOKEN"
+        # Add to devuser's environment
+        echo "export GH_TOKEN='$GITHUB_TOKEN'" >> /home/devuser/.bashrc
+        echo "✓ GitHub CLI (gh) will authenticate automatically"
+    fi
 fi
 
-# Handle GitHub CLI configuration
+# Handle GitHub CLI configuration (backup method)
 if [ -f /tmp/git-mounted/gh-hosts.yml ]; then
     echo "Found mounted GitHub CLI configuration"
     mkdir -p /home/devuser/.config/gh

--- a/docker/scripts/setup-git.sh
+++ b/docker/scripts/setup-git.sh
@@ -81,32 +81,21 @@ echo "  Default branch: $(git config --global init.defaultBranch)"
 echo "  Default editor: $(git config --global core.editor)"
 echo ""
 
-# Ask about GitHub CLI authentication
-echo -n "Would you like to authenticate with GitHub CLI (gh)? (y/N): "
-read -r setup_gh
-
-if [[ "$setup_gh" =~ ^[Yy]$ ]]; then
-    echo ""
-    echo -e "${YELLOW}Setting up GitHub CLI authentication...${NC}"
-    echo "This will open a browser window for authentication."
-    echo ""
-    
-    if command -v gh >/dev/null 2>&1; then
-        gh auth login
-        
-        if gh auth status >/dev/null 2>&1; then
-            echo ""
-            echo -e "${GREEN}✓ GitHub CLI authenticated successfully!${NC}"
-        else
-            echo ""
-            echo -e "${RED}GitHub CLI authentication failed or was cancelled.${NC}"
-        fi
+# Check if gh is available and test authentication
+if command -v gh >/dev/null 2>&1; then
+    echo -e "${BLUE}GitHub CLI Status:${NC}"
+    if gh auth status >/dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} GitHub CLI is authenticated and ready"
+        echo ""
+        echo "You can now use gh commands like:"
+        echo "  gh repo create, gh pr create, gh issue list, etc."
     else
-        echo -e "${RED}GitHub CLI (gh) is not installed.${NC}"
+        echo -e "  ${YELLOW}ℹ${NC} GitHub CLI will authenticate automatically when container starts"
+        echo "  ${YELLOW}ℹ${NC} (using the GitHub token from git configuration)"
     fi
+    echo ""
 fi
 
-echo ""
 echo -e "${GREEN}Git setup complete!${NC}"
 echo ""
 echo "You can always run this script again with:"


### PR DESCRIPTION
## Summary

This PR modernizes GitHub CLI (gh) installation and **eliminates the need for manual `gh auth login`** by automatically setting up authentication from existing git credentials.

## Problem Statement

Currently, users had to run `gh auth login` manually after container startup, even though they already provided GitHub credentials through `setup-container-git-credentials.sh`. This was clunky and redundant.

## Solution

### 1. Installation Improvements

**Before:**
- Complex proxy/non-proxy conditional logic
- Hardcoded fallback version (2.40.1 from ~2023)
- Used `/usr/share/keyrings` directory
- Inconsistent installation methods

**After:**
- Idiomatic installation method from official GitHub CLI docs
- Uses `/etc/apt/keyrings` directory (modern best practice)
- Simplified, single installation path
- Always gets latest version from official repository

### 2. Authentication Improvements

**The Key Change:**
- Extracts GitHub token from `.git-credentials` file
- Automatically sets `GH_TOKEN` environment variable in `.bashrc`
- GitHub CLI now works immediately without any manual authentication

**Before:**
```bash
# After container start
$ gh repo list
To get started with GitHub CLI, please run:  gh auth login
```

**After:**
```bash
# After container start
$ gh repo list
# Works immediately! Lists repositories without prompting
```

## Changes

### Files Modified

1. **`docker/Dockerfile.base`**
   - Updated gh installation to use idiomatic method
   - Removed proxy-specific conditional logic
   - Removed hardcoded version fallback

2. **`docker/entrypoint.base.sh`**
   - Added token extraction from `.git-credentials`
   - Sets `GH_TOKEN` environment variable
   - Added informative log messages

3. **`docker/scripts/setup-git.sh`**
   - Removed manual `gh auth login` prompt
   - Added status check for gh authentication
   - Updated messaging to reflect automatic authentication

## Benefits

- ✅ **Zero manual authentication needed** - `gh` commands work immediately
- ✅ **Consistent user experience** - Uses same token as git operations
- ✅ **Latest versions** - No hardcoded version numbers
- ✅ **Simpler code** - Removed complex conditional logic
- ✅ **Better UX** - Users don't need to know about gh auth at all

## Testing Recommendations

After deploying with these changes:

1. Run `./setup-container-git-credentials.sh` with a GitHub PAT
2. Deploy container with git configuration
3. Shell into container and immediately run:
   ```bash
   gh auth status    # Should show authenticated
   gh repo list      # Should list your repositories
   gh pr list        # Should work without prompting
   ```

## References

- [GitHub CLI Installation Docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
- [GH_TOKEN Environment Variable](https://cli.github.com/manual/gh_help_environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)